### PR TITLE
use gman patched lwjgl jemalloc for ARM64 Linux

### DIFF
--- a/static/mojang/library-patches.json
+++ b/static/mojang/library-patches.json
@@ -561,13 +561,13 @@
           },
           "classifiers": {
             "natives-linux-arm64": {
-              "sha1": "19c7d57e1ab7fee54f35a8615babd5defc355d78",
-              "size": 156163,
-              "url": "https://github.com/theofficialgman/lwjgl3-binaries-arm64/raw/lwjgl-3.2.2/lwjgl-jemalloc-natives-linux-arm64.jar"
+              "sha1": "762d7d80c9cdf3a3f3fc80c8a5f86612255edfe0",
+              "size": 156343,
+              "url": "https://github.com/theofficialgman/lwjgl3-binaries-arm64/raw/lwjgl-3.2.2/lwjgl-jemalloc-patched-natives-linux-arm64.jar"
             }
           }
         },
-        "name": "org.lwjgl:lwjgl-jemalloc:3.2.2-gman64.1",
+        "name": "org.lwjgl:lwjgl-jemalloc:3.2.2-gman64.2",
         "natives": {
           "linux-arm64": "natives-linux-arm64"
         },
@@ -1617,12 +1617,12 @@
       {
         "downloads": {
           "artifact": {
-            "sha1": "c6606e57db075ad218a2e78d2416c159a53b6a0c",
-            "size": 157996,
-            "url": "https://build.lwjgl.org/release/3.3.1/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-linux-arm64.jar"
+            "sha1": "749be48a9b86ee2c3a2da5fd77511208adcfb33b",
+            "size": 159993,
+            "url": "https://github.com/theofficialgman/lwjgl3-binaries-arm64/raw/lwjgl-3.3.1/lwjgl-jemalloc-patched-natives-linux-arm64.jar"
           }
         },
-        "name": "org.lwjgl:lwjgl-jemalloc-natives-linux-arm64:3.3.1-lwjgl.1",
+        "name": "org.lwjgl:lwjgl-jemalloc-natives-linux-arm64:3.3.1-gman64.1",
         "rules": [
           {
             "action": "allow",


### PR DESCRIPTION
Asahi Linux compat (jemalloc compiled with 16K pages support). Includes both lwjgl 3.2.2 and 3.3.1 natives for arm64 linux. Compiled following lwjgl commands with added 16K (`--with-lg-page=16`) pages support

```
CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0" ./autogen.sh --with-jemalloc-prefix=je_ --disable-stats --disable-fill --disable-cxx --with-lg-page=16 --disable-initial-exec-tls
```

Untested on Asahi Linux. Still works on regular 4K pages systems (tested on Nintendo Switch). I don't own macos ARM hardware. I have up till this point been unsuccessful at contacting Asahi Linya, Alyssa Rosenzweig, or yuka for testing.

@Ella-0 if you have a way of contacting these users via github please let me know.

I also requested upstream to make the same change (so future lwjgl versions are compatible without changes) https://github.com/LWJGL/lwjgl3/issues/828