### PR TITLE
Disable Quilt beacon on older versions

### DIFF
--- a/generateQuilt.py
+++ b/generateQuilt.py
@@ -14,6 +14,8 @@ from meta.common.quilt import (
     INTERMEDIARY_COMPONENT,
     LOADER_COMPONENT,
     USE_QUILT_MAPPINGS,
+    DISABLE_BEACON_ARG,
+    DISABLE_BEACON_VERSIONS,
 )
 from meta.model import MetaVersion, Dependency, Library, MetaPackage, GradleSpecifier
 from meta.model.fabric import FabricJarInfo, FabricInstallerDataV1, FabricMainClasses
@@ -62,6 +64,12 @@ def process_loader_version(entry) -> (MetaVersion, bool):
         url="https://maven.quiltmc.org/repository/release",
     )
     v.libraries.append(loader_lib)
+
+    if entry["version"] in DISABLE_BEACON_VERSIONS:
+        if not v.additional_jvm_args:
+            v.additional_jvm_args = []
+        v.additional_jvm_args.append(DISABLE_BEACON_ARG)
+
     return v, should_recommend
 
 

--- a/meta/common/quilt.py
+++ b/meta/common/quilt.py
@@ -15,3 +15,30 @@ INTERMEDIARY_COMPONENT = "org.quiltmc.hashed"
 
 if not USE_QUILT_MAPPINGS:
     INTERMEDIARY_COMPONENT = FABRIC_INTERMEDIARY_COMPONENT
+
+DISABLE_BEACON_ARG = "-Dloader.disable_beacon=true"
+DISABLE_BEACON_VERSIONS = {
+    "0.19.2-beta.3",
+    "0.19.2-beta.4",
+    "0.19.2-beta.5",
+    "0.19.2-beta.6",
+    "0.19.2-beta.7",
+    "0.19.2",
+    "0.19.3-beta.1",
+    "0.19.3",
+    "0.19.4",
+    "0.20.0-beta.1",
+    "0.20.0-beta.2",
+    "0.20.0-beta.3",
+    "0.20.0-beta.4",
+    "0.20.0-beta.5",
+    "0.20.0-beta.6",
+    "0.20.0-beta.7",
+    "0.20.0-beta.8",
+    "0.20.0-beta.9",
+    "0.20.0-beta.10",
+    "0.20.0-beta.11",
+    "0.20.0-beta.12",
+    "0.20.0-beta.13",
+    "0.20.0-beta.14",
+}


### PR DESCRIPTION
Let's wait until the beacon is actually removed, as per https://github.com/QuiltMC/rfcs/pull/84
