### PR TITLE
updateFabric.py: add missing `import requests`

### DIFF
--- a/updateFabric.py
+++ b/updateFabric.py
@@ -3,6 +3,8 @@ import os
 import zipfile
 from datetime import datetime
 
+import requests
+
 from meta.common import (
     upstream_path,
     ensure_upstream_dir,


### PR DESCRIPTION
Needed for catching `requests.HTTPError` later in the file.