### PR TITLE
do not remove minecraftArguments for legacy override versions

### DIFF
--- a/meta/model/mojang.py
+++ b/meta/model/mojang.py
@@ -136,8 +136,6 @@ class LegacyOverrideEntry(MetaBase):
         if legacy:
             # remove all libraries - they are not needed for legacy
             meta_version.libraries = None
-            # remove minecraft arguments - we use our own hardcoded ones
-            meta_version.minecraft_arguments = None
 
 
 class LegacyOverrideIndex(MetaBase):


### PR DESCRIPTION
[discussion on discord](https://discord.com/channels/1031648380885147709/1031823065937629267/1183155928409841745)
resolves https://github.com/PrismLauncher/PrismLauncher/issues/1580

when [noapplet is used with legacyLaunch](https://github.com/PrismLauncher/PrismLauncher/blob/ad6ca1c6ea6bede085ee7dd1385e3aef24fad9ae/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java#L123C34-L123C34), `AbstractLauncher::gameArgs` is always empty (or just contains `--demo`) because when generating the meta, [minecraftArguments are removed](https://github.com/PrismLauncher/meta/blob/eb47993bf859d0c2b5f3cf119a022c178c24ef30/meta/model/mojang.py#L139-L140), which causes the there to be no params entry for it. There is some legacy code in [MojangVersionFormat.cpp](https://github.com/PrismLauncher/PrismLauncher/blob/ad6ca1c6ea6bede085ee7dd1385e3aef24fad9ae/launcher/minecraft/MojangVersionFormat.cpp#L164) that might be meant to handle this but at current it is almost entirely unused. This pr simply removes the code that nullified the default arguments.

I tested this change in a couple versions, "noapplet" with a1.2.6 causes some IndexOutOfBounds exception with or without minecraftArguments set, and with this fix b1.7.3 and 1.3.2 get sessionIds and usernames passed through with noapplet, which in turn lets legacyFixes find skins, whereas without minecraftArguments set it behaves how I laid out in the original issue.