### PR TITLE
Renamed old_snapshot to snapshot

### DIFF
--- a/meta/common/mojang-minecraft-experiments.json
+++ b/meta/common/mojang-minecraft-experiments.json
@@ -53,7 +53,7 @@
     {
       "id": "1_16_combat-4",
       "wiki": "https://minecraft.wiki/w/Java_Edition_Combat_Test_8",
-      "url": "https://cdn.discordapp.com/attachments/369990015096455168/947864881028272198/1_16_combat-4.zip"
+      "url": "https://archive.org/download/1-16-combat-4_202404/1_16_combat-4.zip"
     },
     {
       "id": "1_16_combat-3",

--- a/meta/run/update_mojang.py
+++ b/meta/run/update_mojang.py
@@ -61,7 +61,7 @@ def fetch_modified_version(path, version):
     }
 
     version_json["downloads"] = downloads
-    version_json["type"] = "old_snapshot"
+    version_json["type"] = "snapshot"
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(version_json, f, sort_keys=True, indent=4)

--- a/meta/run/update_mojang.py
+++ b/meta/run/update_mojang.py
@@ -41,6 +41,7 @@ def fetch_zipped_version(path, url):
                 break
 
     assert version_json
+    version_json["type"] = version_json["type"].removeprefix("old_")
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(version_json, f, sort_keys=True, indent=4)
@@ -61,7 +62,7 @@ def fetch_modified_version(path, version):
     }
 
     version_json["downloads"] = downloads
-    version_json["type"] = "snapshot"
+    version_json["type"] = version_json["type"].removeprefix("old_")
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(version_json, f, sort_keys=True, indent=4)
@@ -74,6 +75,7 @@ def fetch_version(path, url):
     r.raise_for_status()
     version_json = r.json()
 
+    version_json["type"] = version_json["type"].removeprefix("old_")
     with open(path, "w", encoding="utf-8") as f:
         json.dump(version_json, f, sort_keys=True, indent=4)
 


### PR DESCRIPTION
[PR#2292](https://github.com/PrismLauncher/PrismLauncher/pull/2292)

This should prepare things for the removal of `old_*` entries in the UI .

Replaces: https://github.com/PrismLauncher/meta/pull/39