### PR TITLE
Removed old_ prefix from type

### DIFF
--- a/meta/model/mojang.py
+++ b/meta/model/mojang.py
@@ -269,6 +269,8 @@ class MojangVersion(MetaBase):
 
         if new_type == "pending":  # experiments from upstream are type=pending
             new_type = "experiment"
+        else:
+            new_type = new_type.removeprefix("old_")
 
         return MetaVersion(
             name=name,

--- a/meta/run/update_mojang.py
+++ b/meta/run/update_mojang.py
@@ -61,7 +61,6 @@ def fetch_modified_version(path, version):
     }
 
     version_json["downloads"] = downloads
-    version_json["type"] = "old_snapshot"
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(version_json, f, sort_keys=True, indent=4)


### PR DESCRIPTION
This is the successor of https://github.com/PrismLauncher/meta/pull/43 after it's reverted.
Please do not merge until 8.4 is released