### PR TITLE
Improve performance by using concurrent.futures

### DIFF
--- a/meta/run/update_fabric.py
+++ b/meta/run/update_fabric.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import json
 import os
 import zipfile
@@ -93,6 +94,30 @@ def compute_jar_file(path, url):
     data.write(path + ".json")
 
 
+def compute_jar_file_concurrent(component, it):
+    print(f"Processing {component} {it['version']} ")
+    jar_maven_url = get_maven_url(
+        it["maven"], "https://maven.fabricmc.net/", ".jar"
+    )
+    compute_jar_file(
+        os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
+        jar_maven_url,
+    )
+    print(f"Processing {component} {it['version']} Done")
+
+
+def get_json_file_concurrent(it):
+    print(f"Downloading JAR info for loader {it['version']} ")
+    maven_url = get_maven_url(
+        it["maven"], "https://maven.fabricmc.net/", ".json"
+    )
+    get_json_file(
+        os.path.join(UPSTREAM_DIR, INSTALLER_INFO_DIR, f"{it['version']}.json"),
+        maven_url,
+    )
+    print(f"Downloading JAR info for loader {it['version']} Done")
+
+
 def main():
     # get the version list for each component we are interested in
     for component in ["intermediary", "loader"]:
@@ -100,30 +125,37 @@ def main():
             os.path.join(UPSTREAM_DIR, META_DIR, f"{component}.json"),
             "https://meta.fabricmc.net/v2/versions/" + component,
         )
-        for it in index:
-            print(f"Processing {component} {it['version']} ")
-            jar_maven_url = get_maven_url(
-                it["maven"], "https://maven.fabricmc.net/", ".jar"
-            )
-            compute_jar_file(
-                os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
-                jar_maven_url,
-            )
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for it in index:
+                executor.submit(compute_jar_file_concurrent, component, it)
+
+        # for it in index:
+        #     print(f"Processing {component} {it['version']} ")
+        #     jar_maven_url = get_maven_url(
+        #         it["maven"], "https://maven.fabricmc.net/", ".jar"
+        #     )
+        #     compute_jar_file(
+        #         os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
+        #         jar_maven_url,
+        #     )
 
     # for each loader, download installer JSON file from maven
     with open(
         os.path.join(UPSTREAM_DIR, META_DIR, "loader.json"), "r", encoding="utf-8"
     ) as loaderVersionIndexFile:
         loader_version_index = json.load(loaderVersionIndexFile)
-        for it in loader_version_index:
-            print(f"Downloading JAR info for loader {it['version']} ")
-            maven_url = get_maven_url(
-                it["maven"], "https://maven.fabricmc.net/", ".json"
-            )
-            get_json_file(
-                os.path.join(UPSTREAM_DIR, INSTALLER_INFO_DIR, f"{it['version']}.json"),
-                maven_url,
-            )
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for it in loader_version_index:
+                executor.submit(get_json_file_concurrent, it)
+        # for it in loader_version_index:
+        #     print(f"Downloading JAR info for loader {it['version']} ")
+        #     maven_url = get_maven_url(
+        #         it["maven"], "https://maven.fabricmc.net/", ".json"
+        #     )
+        #     get_json_file(
+        #         os.path.join(UPSTREAM_DIR, INSTALLER_INFO_DIR, f"{it['version']}.json"),
+        #         maven_url,
+        #     )
 
 
 if __name__ == "__main__":

--- a/meta/run/update_fabric.py
+++ b/meta/run/update_fabric.py
@@ -96,9 +96,7 @@ def compute_jar_file(path, url):
 
 def compute_jar_file_concurrent(component, it):
     print(f"Processing {component} {it['version']} ")
-    jar_maven_url = get_maven_url(
-        it["maven"], "https://maven.fabricmc.net/", ".jar"
-    )
+    jar_maven_url = get_maven_url(it["maven"], "https://maven.fabricmc.net/", ".jar")
     compute_jar_file(
         os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
         jar_maven_url,
@@ -108,9 +106,7 @@ def compute_jar_file_concurrent(component, it):
 
 def get_json_file_concurrent(it):
     print(f"Downloading JAR info for loader {it['version']} ")
-    maven_url = get_maven_url(
-        it["maven"], "https://maven.fabricmc.net/", ".json"
-    )
+    maven_url = get_maven_url(it["maven"], "https://maven.fabricmc.net/", ".json")
     get_json_file(
         os.path.join(UPSTREAM_DIR, INSTALLER_INFO_DIR, f"{it['version']}.json"),
         maven_url,

--- a/meta/run/update_mojang.py
+++ b/meta/run/update_mojang.py
@@ -81,17 +81,10 @@ def fetch_version(path, url):
     return version_json
 
 
-def fetch_version_concurrent(remote_versions,x):
+def fetch_version_concurrent(remote_versions, x):
     version = remote_versions.versions[x]
-    print(
-        "Updating "
-        + version.id
-        + " to timestamp "
-        + version.release_time.strftime("%s")
-    )
-    fetch_version(
-        os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json"), version.url
-    )
+    print("Updating " + version.id + " to timestamp " + version.release_time.strftime("%s"))
+    fetch_version(os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json"), version.url)
 
 
 def fetch_modified_version_concurrent(old_snapshots, x):

--- a/meta/run/update_mojang.py
+++ b/meta/run/update_mojang.py
@@ -83,7 +83,12 @@ def fetch_version(path, url):
 
 def fetch_version_concurrent(remote_versions, x):
     version = remote_versions.versions[x]
-    print("Updating " + version.id + " to timestamp " + version.release_time.strftime("%s"))
+    print(
+        "Updating "
+        + version.id
+        + " to timestamp "
+        + version.release_time.strftime("%s")
+    )
     fetch_version(os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json"), version.url)
 
 

--- a/meta/run/update_mojang.py
+++ b/meta/run/update_mojang.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import json
 import os
 import zipfile
@@ -80,6 +81,30 @@ def fetch_version(path, url):
     return version_json
 
 
+def fetch_version_concurrent(remote_versions,x):
+    version = remote_versions.versions[x]
+    print(
+        "Updating "
+        + version.id
+        + " to timestamp "
+        + version.release_time.strftime("%s")
+    )
+    fetch_version(
+        os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json"), version.url
+    )
+
+
+def fetch_modified_version_concurrent(old_snapshots, x):
+    version = old_snapshots.versions[x]
+    old_snapshots_path = os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json")
+
+    print("Updating old snapshot " + version.id)
+    if not os.path.isfile(old_snapshots_path):
+        fetch_modified_version(old_snapshots_path, version)
+    else:
+        print("Already have old snapshot " + version.id)
+
+
 def main():
     # get the remote version list
     r = sess.get("https://piston-meta.mojang.com/mc/game/version_manifest_v2.json")
@@ -108,17 +133,21 @@ def main():
     else:
         pending_ids = remote_ids
 
-    for x in pending_ids:
-        version = remote_versions.versions[x]
-        print(
-            "Updating "
-            + version.id
-            + " to timestamp "
-            + version.release_time.strftime("%s")
-        )
-        fetch_version(
-            os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json"), version.url
-        )
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for x in pending_ids:
+            executor.submit(fetch_version_concurrent, remote_versions, x)
+
+    # for x in pending_ids:
+    #     version = remote_versions.versions[x]
+    #     print(
+    #         "Updating "
+    #         + version.id
+    #         + " to timestamp "
+    #         + version.release_time.strftime("%s")
+    #     )
+    #     fetch_version(
+    #         os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json"), version.url
+    #     )
 
     # deal with experimental snapshots separately
     if os.path.exists(STATIC_EXPERIMENTS_FILE):
@@ -144,15 +173,19 @@ def main():
         )
         old_snapshots_ids = set(old_snapshots.versions.keys())
 
-        for x in old_snapshots_ids:
-            version = old_snapshots.versions[x]
-            old_snapshots_path = os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json")
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for x in old_snapshots_ids:
+                executor.submit(fetch_modified_version_concurrent, old_snapshots, x)
 
-            print("Updating old snapshot " + version.id)
-            if not os.path.isfile(old_snapshots_path):
-                fetch_modified_version(old_snapshots_path, version)
-            else:
-                print("Already have old snapshot " + version.id)
+        # for x in old_snapshots_ids:
+        #     version = old_snapshots.versions[x]
+        #     old_snapshots_path = os.path.join(UPSTREAM_DIR, VERSIONS_DIR, f"{x}.json")
+        #
+        #     print("Updating old snapshot " + version.id)
+        #     if not os.path.isfile(old_snapshots_path):
+        #         fetch_modified_version(old_snapshots_path, version)
+        #     else:
+        #         print("Already have old snapshot " + version.id)
 
     remote_versions.index.write(version_manifest_path)
 

--- a/meta/run/update_quilt.py
+++ b/meta/run/update_quilt.py
@@ -105,6 +105,7 @@ def get_json_file_concurrent(it):
         maven_url,
     )
 
+
 def main():
     # get the version list for each component we are interested in
     components = ["loader"]

--- a/meta/run/update_quilt.py
+++ b/meta/run/update_quilt.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import json
 import os
 import zipfile
@@ -82,6 +83,28 @@ def compute_jar_file(path, url):
     data.write(path + ".json")
 
 
+def compute_jar_file_concurrent(component, it):
+    print(f"Processing {component} {it['version']} ")
+    jar_maven_url = get_maven_url(
+        it["maven"], "https://maven.quiltmc.org/repository/release/", ".jar"
+    )
+    compute_jar_file(
+        os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
+        jar_maven_url,
+    )
+    print(f"Processing {component} {it['version']} Done")
+
+
+def get_json_file_concurrent(it):
+    print(f"Downloading JAR info for loader {it['version']} ")
+    maven_url = get_maven_url(
+        it["maven"], "https://maven.quiltmc.org/repository/release/", ".json"
+    )
+    get_json_file(
+        os.path.join(UPSTREAM_DIR, INSTALLER_INFO_DIR, f"{it['version']}.json"),
+        maven_url,
+    )
+
 def main():
     # get the version list for each component we are interested in
     components = ["loader"]
@@ -92,30 +115,37 @@ def main():
             os.path.join(UPSTREAM_DIR, META_DIR, f"{component}.json"),
             "https://meta.quiltmc.org/v3/versions/" + component,
         )
-        for it in index:
-            print(f"Processing {component} {it['version']} ")
-            jar_maven_url = get_maven_url(
-                it["maven"], "https://maven.quiltmc.org/repository/release/", ".jar"
-            )
-            compute_jar_file(
-                os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
-                jar_maven_url,
-            )
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for it in index:
+                executor.submit(compute_jar_file_concurrent, component, it)
+
+        # for it in index:
+        #     print(f"Processing {component} {it['version']} ")
+        #     jar_maven_url = get_maven_url(
+        #         it["maven"], "https://maven.quiltmc.org/repository/release/", ".jar"
+        #     )
+        #     compute_jar_file(
+        #         os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
+        #         jar_maven_url,
+        #     )
 
     # for each loader, download installer JSON file from maven
     with open(
         os.path.join(UPSTREAM_DIR, META_DIR, "loader.json"), "r", encoding="utf-8"
     ) as loaderVersionIndexFile:
         loader_version_index = json.load(loaderVersionIndexFile)
-        for it in loader_version_index:
-            print(f"Downloading JAR info for loader {it['version']} ")
-            maven_url = get_maven_url(
-                it["maven"], "https://maven.quiltmc.org/repository/release/", ".json"
-            )
-            get_json_file(
-                os.path.join(UPSTREAM_DIR, INSTALLER_INFO_DIR, f"{it['version']}.json"),
-                maven_url,
-            )
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for it in loader_version_index:
+                executor.submit(get_json_file_concurrent, it)
+        # for it in loader_version_index:
+        #     print(f"Downloading JAR info for loader {it['version']} ")
+        #     maven_url = get_maven_url(
+        #         it["maven"], "https://maven.quiltmc.org/repository/release/", ".json"
+        #     )
+        #     get_json_file(
+        #         os.path.join(UPSTREAM_DIR, INSTALLER_INFO_DIR, f"{it['version']}.json"),
+        #         maven_url,
+        #     )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recently I want to use this script for my personal project, then I found that if I don't clone meta-upstream to ``upstream/``, it will take a lot of time to generate data when using ``./update.sh``.

## What I do
This is just an example.

I just turn
```python
...
for it in index:
    print(f"Processing {component} {it['version']} ")
    jar_maven_url = get_maven_url(
        it["maven"], "https://maven.fabricmc.net/", ".jar"
    )
    compute_jar_file(
        os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
        jar_maven_url,
    )
...
```
into
```python
...
def compute_jar_file_concurrent(component, it):
    print(f"Processing {component} {it['version']} ")
    jar_maven_url = get_maven_url(
        it["maven"], "https://maven.fabricmc.net/", ".jar"
    )
    compute_jar_file(
        os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(it["maven"])),
        jar_maven_url,
    )
    print(f"Processing {component} {it['version']} Done")
...
```


```python
...
with concurrent.futures.ThreadPoolExecutor() as executor:
    for it in index:
        executor.submit(compute_jar_file_concurrent, component, it)
...
```

## Comparison
Here is the time comparison about what the code what I change. 
(Left side is my code, Right side is the original code.)
![image](https://github.com/PrismLauncher/meta/assets/44264182/9a98799e-0461-4d6d-9882-52e676f3fc31)

Here is my test enviroment information:
```bash
OS: Arch Linux x86_64 
Kernel: 6.9.1-zen1-2-zen 
Uptime: 2 hours, 35 mins 
Terminal: kitty 
CPU: 12th Gen Intel i5-12400 (12) @ 4.400GHz 
GPU: NVIDIA GeForce RTX 3060 
GPU: Intel Alder Lake-S GT1 [UHD Graphics 730] 
Memory: 10164MiB / 31837MiB 
```
#

## Note
~~I have noticed some order change in launcher/net.fabricmc.intermediary/index.json,these also change sha in launcher/index.json. I just need to figure out what happened in these change.~~
![image](https://github.com/PrismLauncher/meta/assets/44264182/e0356741-b998-44d8-a726-c2cb1a89c2e1)

