### PR TITLE
Add support for Cleanroom, introduce `satisfies` field

### DIFF
--- a/meta/common/cleanroom.py
+++ b/meta/common/cleanroom.py
@@ -1,0 +1,5 @@
+BASE_DIR = "cleanroom"
+VERSIONS_FILE = "cleanroom/versions.json"
+COMPONENT = "com.cleanroommc.cleanroom"
+GITHUB_REPO = "CleanroomMC/Cleanroom"
+MINECRAFT_VERSION = "1.12.2"

--- a/meta/common/http.py
+++ b/meta/common/http.py
@@ -1,3 +1,20 @@
+def get_github_releases(sess, repo: str) -> list[dict]:
+    releases = []
+    page = 1
+    while True:
+        r = sess.get(
+            f"https://api.github.com/repos/{repo}/releases",
+            params={"per_page": 100, "page": page},
+        )
+        r.raise_for_status()
+        batch = r.json()
+        if not batch:
+            break
+        releases.extend(batch)
+        page += 1
+    return releases
+
+
 def download_binary_file(sess, path, url):
     with open(path, "wb") as f:
         r = sess.get(url)

--- a/meta/model/__init__.py
+++ b/meta/model/__init__.py
@@ -329,6 +329,7 @@ class MetaVersion(Versioned):
     volatile: Optional[bool]
     requires: Optional[List[Dependency]]
     conflicts: Optional[List[Dependency]]
+    satisfies: Optional[List[Dependency]]
     libraries: Optional[List[Library]]
     asset_index: Optional[MojangAssets] = Field(alias="assetIndex")
     maven_files: Optional[List[Library]] = Field(alias="mavenFiles")

--- a/meta/run/generate_cleanroom.py
+++ b/meta/run/generate_cleanroom.py
@@ -1,0 +1,178 @@
+import json
+import os
+from datetime import datetime, timezone
+
+from meta.common import ensure_component_dir, launcher_path, upstream_path
+from meta.common.cleanroom import BASE_DIR, VERSIONS_FILE, COMPONENT, MINECRAFT_VERSION
+from meta.model import (
+    Dependency,
+    GradleSpecifier,
+    Library,
+    MetaPackage,
+    MetaVersion,
+    MojangArtifact,
+    MojangLibraryDownloads,
+)
+
+CONFLICTS = [
+    "net.minecraftforge",
+    "net.neoforged",
+    "net.fabricmc.fabric-loader",
+    "org.quiltmc.quilt-loader",
+    "org.lwjgl",
+]
+
+
+def parse_library(raw: dict) -> Library:
+    name = GradleSpecifier.from_string(raw["name"])
+    downloads = None
+    if "downloads" in raw:
+        artifact = None
+        if "artifact" in raw["downloads"]:
+            a = raw["downloads"]["artifact"]
+            artifact = MojangArtifact(
+                url=a["url"],
+                sha1=a.get("sha1"),
+                size=a.get("size"),
+                path=a.get("path"),
+            )
+        downloads = MojangLibraryDownloads(artifact=artifact)
+    url = raw.get("url")
+    return Library(name=name, downloads=downloads, url=url)
+
+
+def parse_release_time(raw: dict) -> datetime:
+    ts = raw.get("releaseTime", "1970-01-01T00:00:00+00:00")
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        return datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def process_version(tag: str, patch: dict, lwjgl3_version: str | None) -> MetaVersion:
+    version = patch.get("version", tag)
+
+    v = MetaVersion(
+        name="Cleanroom",
+        uid=COMPONENT,
+        version=version,
+        release_time=parse_release_time(patch),
+        requires=[
+            Dependency(uid="net.minecraft", equals=MINECRAFT_VERSION),
+            Dependency(uid="org.lwjgl3", suggests=lwjgl3_version),
+        ],
+        conflicts=[Dependency(uid=uid) for uid in CONFLICTS],
+        satisfies=[Dependency(uid="org.lwjgl")],
+        main_class=patch.get("mainClass"),
+        additional_tweakers=patch.get("+tweakers"),
+        additional_jvm_args=patch.get("+jvmArgs"),
+        libraries=[parse_library(lib) for lib in patch.get("libraries", [])],
+        order=10,
+        type="alpha",
+    )
+    return v
+
+
+def main():
+    launcher_dir = launcher_path()
+    upstream_dir = upstream_path()
+
+    ensure_component_dir(COMPONENT)
+    ensure_component_dir("net.minecraft")
+    ensure_component_dir("org.lwjgl3")
+
+    index_path = os.path.join(upstream_dir, VERSIONS_FILE)
+    with open(index_path, "r", encoding="utf-8") as f:
+        index = json.load(f)
+
+    recommended: str | None = None
+    lwjgl3_versions: dict[str, dict] = {}
+    recommended_minecraft_patch: dict | None = None
+
+    for entry in index:
+        tag = entry["version"]
+        patch_path = os.path.join(upstream_dir, BASE_DIR, f"{tag}.json")
+        if not os.path.exists(patch_path):
+            print(f"Missing upstream for {tag}, skipping")
+            continue
+
+        with open(patch_path, "r", encoding="utf-8") as f:
+            patch = json.load(f)
+
+        lwjgl3_version = None
+
+        lwjgl3_patch_path = os.path.join(upstream_dir, BASE_DIR, f"{tag}-lwjgl3.json")
+        if os.path.exists(lwjgl3_patch_path):
+            with open(lwjgl3_patch_path, "r", encoding="utf-8") as f:
+                lwjgl3_patch = json.load(f)
+            lwjgl3_version = lwjgl3_patch.get("version")
+            if lwjgl3_version and lwjgl3_version not in lwjgl3_versions:
+                lwjgl3_versions[lwjgl3_version] = lwjgl3_patch
+
+        minecraft_patch_path = os.path.join(
+            upstream_dir, BASE_DIR, f"{tag}-minecraft.json"
+        )
+        minecraft_patch = None
+        if os.path.exists(minecraft_patch_path):
+            with open(minecraft_patch_path, "r", encoding="utf-8") as f:
+                minecraft_patch = json.load(f)
+
+        java_majors = (
+            minecraft_patch.get("compatibleJavaMajors", []) if minecraft_patch else []
+        )
+        print(
+            f"Processing Cleanroom {tag} (mc={MINECRAFT_VERSION}, lwjgl3={lwjgl3_version}, java={java_majors})"
+        )
+        v = process_version(tag, patch, lwjgl3_version)
+
+        if recommended is None:
+            recommended = v.version
+            recommended_minecraft_patch = minecraft_patch
+
+        v.write(os.path.join(launcher_dir, COMPONENT, f"{v.version}.json"))
+
+    if recommended_minecraft_patch:
+        dest = os.path.join(launcher_dir, "net.minecraft", f"{MINECRAFT_VERSION}.json")
+        with open(dest, "w", encoding="utf-8") as f:
+            json.dump(recommended_minecraft_patch, f, sort_keys=True, indent=4)
+        MetaPackage(
+            uid="net.minecraft", name="Minecraft", recommended=[MINECRAFT_VERSION]
+        ).write(os.path.join(launcher_dir, "net.minecraft", "package.json"))
+        print(f"Wrote patched net.minecraft {MINECRAFT_VERSION}")
+
+    for lwjgl3_version, lwjgl3_patch in lwjgl3_versions.items():
+        dest = os.path.join(launcher_dir, "org.lwjgl3", f"{lwjgl3_version}.json")
+        with open(dest, "w", encoding="utf-8") as f:
+            json.dump(lwjgl3_patch, f, sort_keys=True, indent=4)
+        print(f"Wrote org.lwjgl3 {lwjgl3_version}")
+    if lwjgl3_versions:
+
+        def lwjgl3_version_key(v: str) -> tuple[int, ...]:
+            return tuple(int(x) for x in v.split("-")[0].split("."))
+
+        lwjgl3_recommended = sorted(
+            lwjgl3_versions.keys(), key=lwjgl3_version_key, reverse=True
+        )
+        MetaPackage(
+            uid="org.lwjgl3", name="LWJGL 3", recommended=[lwjgl3_recommended[0]]
+        ).write(os.path.join(launcher_dir, "org.lwjgl3", "package.json"))
+
+    package = MetaPackage(
+        uid=COMPONENT,
+        name="Cleanroom",
+        recommended=[recommended] if recommended else [],
+        description=(
+            "Cleanroom is a Forge-compatible mod loader for Minecraft 1.12.2 "
+            "with support for modern Java (Java 25+)."
+        ),
+        project_url="https://github.com/CleanroomMC/Cleanroom",
+        authors=["CleanroomMC"],
+    )
+    package.write(os.path.join(launcher_dir, COMPONENT, "package.json"))
+    print(f"Done. Recommended: {recommended or 'none'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/meta/run/update_cleanroom.py
+++ b/meta/run/update_cleanroom.py
@@ -1,0 +1,79 @@
+import io
+import json
+import os
+import zipfile
+
+from meta.common import upstream_path, ensure_upstream_dir, default_session
+from meta.common.cleanroom import BASE_DIR, VERSIONS_FILE, GITHUB_REPO
+from meta.common.http import get_github_releases
+
+UPSTREAM_DIR = upstream_path()
+
+ensure_upstream_dir(BASE_DIR)
+
+sess = default_session()
+
+
+PATCHES = {
+    "net.minecraftforge.json": "{tag}.json",
+    "net.minecraft.json": "{tag}-minecraft.json",
+    "org.lwjgl3.json": "{tag}-lwjgl3.json",
+}
+
+
+def get_mmc_patches(tag: str) -> dict[str, dict]:
+    zip_url = (
+        f"https://github.com/{GITHUB_REPO}/releases/download/"
+        f"{tag}/Cleanroom-MMC-instance-{tag}.zip"
+    )
+    r = sess.get(zip_url)
+    r.raise_for_status()
+    result = {}
+    with zipfile.ZipFile(io.BytesIO(r.content)) as zf:
+        for patch_name in PATCHES:
+            with zf.open(f"patches/{patch_name}") as f:
+                result[patch_name] = json.load(f)
+    return result
+
+
+def main():
+    releases = get_github_releases(sess, GITHUB_REPO)
+
+    versions = []
+    for release in releases:
+        tag = release["tag_name"]
+        published_at = release["published_at"]
+
+        dest_paths = [
+            os.path.join(UPSTREAM_DIR, BASE_DIR, dest_template.format(tag=tag))
+            for dest_template in PATCHES.values()
+        ]
+        if all(os.path.exists(p) for p in dest_paths):
+            print(f"Already have Cleanroom {tag}")
+            versions.append({"version": tag, "published_at": published_at})
+            continue
+
+        print(f"Downloading Cleanroom {tag}")
+        try:
+            patches = get_mmc_patches(tag)
+        except Exception as e:
+            print(f"  Skipping {tag}: {e}")
+            continue
+
+        for patch_name, dest_template in PATCHES.items():
+            patch = patches[patch_name]
+            patch.setdefault("releaseTime", published_at)
+            dest = os.path.join(UPSTREAM_DIR, BASE_DIR, dest_template.format(tag=tag))
+            with open(dest, "w", encoding="utf-8") as f:
+                json.dump(patch, f, sort_keys=True, indent=4)
+
+        versions.append({"version": tag, "published_at": published_at})
+
+    index_path = os.path.join(UPSTREAM_DIR, VERSIONS_FILE)
+    with open(index_path, "w", encoding="utf-8") as f:
+        json.dump(versions, f, sort_keys=True, indent=4)
+    print(f"Wrote index with {len(versions)} versions")
+
+
+if __name__ == "__main__":
+    main()

--- a/update.sh
+++ b/update.sh
@@ -41,6 +41,7 @@ python -m meta.run.update_neoforge || fail_in
 python -m meta.run.update_fabric || fail_in
 python -m meta.run.update_quilt || fail_in
 python -m meta.run.update_liteloader || fail_in
+python -m meta.run.update_cleanroom || fail_in
 python -m meta.run.update_java || fail_in
 
 if [ "${DEPLOY_TO_GIT}" = true ]; then
@@ -50,6 +51,7 @@ if [ "${DEPLOY_TO_GIT}" = true ]; then
     upstream_git add fabric/loader-installer-json/*.json fabric/meta-v2/*.json fabric/jars/*.json || fail_in
     upstream_git add quilt/loader-installer-json/*.json quilt/meta-v3/*.json quilt/jars/*.json || fail_in
     upstream_git add liteloader/*.json || fail_in
+    upstream_git add cleanroom/*.json || fail_in
     upstream_git add java_runtime/adoptium/available_releases.json java_runtime/adoptium/versions/*.json java_runtime/azul/packages.json java_runtime/azul/versions/*.json java_runtime/ibm/available_releases.json java_runtime/ibm/versions/*.json || fail_in
     if ! upstream_git diff --cached --exit-code; then
         upstream_git commit -a -m "Update ${currentDate}" || fail_in
@@ -66,6 +68,7 @@ python -m meta.run.generate_neoforge || fail_out
 python -m meta.run.generate_fabric || fail_out
 python -m meta.run.generate_quilt || fail_out
 python -m meta.run.generate_liteloader || fail_out
+python -m meta.run.generate_cleanroom || fail_out
 python -m meta.run.generate_java || fail_out
 python -m meta.run.index || fail_out
 
@@ -76,6 +79,7 @@ if [ "${DEPLOY_TO_GIT}" = true ]; then
     launcher_git add net.fabricmc.fabric-loader/* net.fabricmc.intermediary/* || fail_out
     launcher_git add org.quiltmc.quilt-loader/* || fail_out # TODO: add Quilt hashed, once it is actually used
     launcher_git add com.mumfrey.liteloader/* || fail_out
+    launcher_git add com.cleanroommc.cleanroom/* || fail_out
     launcher_git add net.minecraft.java/* net.adoptium.java/* com.azul.java/* com.ibm.java/* || fail_out
 
     if ! launcher_git diff --cached --exit-code; then


### PR DESCRIPTION
tldr: This PR introduces preliminary support for https://github.com/PrismLauncher/PrismLauncher/issues/2551: I have a PR ready for the launcher side, but I will wait to push it until the meta format is merged (partially since I have to go back and forth between the Metadata Server to test it as it stands).

--- 

This introduces a `satisfies` field to MetaVersion, analogous to other package managers `Provides` field. A component that declares satisfies: [{uid: "foo"}] tells the resolver that the requirement for foo is met, without foo itself being installed.

Minecraft 1.12.2 requires org.lwjgl (LWJGL 2), but Cleanroom requires org.lwjgl3 (LWJGL 3) and cannot coexist with LWJGL 2. Without `satisfies`, the resolver would either incorrectly add LWJGL 2 alongside Cleanroom, or report a missing dependency error that cannot be resolved. There are a few other ways this could be solved, but they would have ill consequences:
- Patching `net.minecraft` to not require `org.lwjgl` would break Forge/vanilla support (this is what cleanroom's zip does, which are installed on a per-modpack basis)
- Using a separate uid for minecraft (e.g `net.minecraft:1.12.2-lwjgl3`) would require duplicating all its metadata, and complicates the launcher's filtering logic
- Ignoring and suppressing the error from the launcher during dependency resolution probably doesn't scale well.

---

With this, Cleanroom declares that it:
- requires `[net.minecraft:1.12.2, org.lwjgl3]` (both of which are true),
- conflicts with `[org.lwjgl, forge, ...]` (implying that the launcher must remove LWJGL 2 since it's a dep-only component),
- and satisfies `org.lwjgl` (to keep Minecraft 1.12 happy).

---

I was unable to run `./update.sh` since it fails at missing zip files for older forge versions; but I think I've updated it correctly. Instead I just ran these commands manually:
```sh
nix develop --command python -m meta.run.update_cleanroom
nix develop --command python -m meta.run.generate_cleanroom
nix develop --command python -m meta.run.index
```