### PR TITLE
Fix webrtc-java on arm macOS / Linux

### DIFF
--- a/meta/common/mojang-library-patches.json
+++ b/meta/common/mojang-library-patches.json
@@ -4506,5 +4506,53 @@
         ]
       }
     ]
+  },
+  {
+    "_comment": "Only allow osx-arm64 for existing webrtc-java",
+    "match": [
+      "dev.onvoid.webrtc:webrtc-java:0.14.0:macos-aarch64"
+    ],
+    "override": {
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx-arm64"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "_comment": "Only allow linux-arm64 for existing webrtc-java",
+    "match": [
+      "dev.onvoid.webrtc:webrtc-java:0.14.0:linux-aarch64"
+    ],
+    "override": {
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux-arm64"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "_comment": "Only allow linux-arm32 for existing webrtc-java",
+    "match": [
+      "dev.onvoid.webrtc:webrtc-java:0.14.0:linux-aarch32"
+    ],
+    "override": {
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux-arm32"
+          }
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
This fixes the P2P multiplayer feature added in 26.2-snapshot-7.

Tested only on macOS.