### PR TITLE
add new lwjgl variant

### DIFF
--- a/meta/common/mojang-library-patches.json
+++ b/meta/common/mojang-library-patches.json
@@ -3786,7 +3786,8 @@
   {
     "_comment": "Add linux-arm64 support for LWJGL 3.4.1",
     "match": [
-      "org.lwjgl:lwjgl:3.4.1"
+      "org.lwjgl:lwjgl:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {
@@ -3994,7 +3995,8 @@
   {
     "_comment": "Add linux-arm32 support for LWJGL 3.4.1",
     "match": [
-      "org.lwjgl:lwjgl:3.4.1"
+      "org.lwjgl:lwjgl:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {
@@ -4358,7 +4360,8 @@
   {
     "_comment": "Add linux-riscv64 support for LWJGL 3.4.1",
     "match": [
-      "org.lwjgl:lwjgl:3.4.1"
+      "org.lwjgl:lwjgl:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {

--- a/meta/run/generate_mojang.py
+++ b/meta/run/generate_mojang.py
@@ -91,7 +91,7 @@ LOG4J_HASHES = {
 # We want versions that contain natives for all platforms. If there are multiple, pick the latest one
 # LWJGL versions we want
 PASS_VARIANTS = [
-    "472ee33f7a1294822aa2d617cd6ccdfd92f949a0",  # 3.4.1 (2026-04-07 11:52:43+00:00) vulkan
+    "0ab5c885c21dfd8133277e8f557839f5fab35311",  # 3.4.1 (2026-05-26 13:48:31+00:00) fixed performance regressions
     "2b00f31688148fc95dbc8c8ef37308942cf0dce0",  # 3.3.6 (2025-10-21 11:38:51+00:00)
     "73974b3af2afeb5b272ffbadcd7963014387c84f",  # 3.3.3 (2024-05-22 16:25:41+00:00)
     "765b4ab443051d286bdbb1c19cd7dc86b0792dce",  # 3.3.2 (2024-01-17 13:19:20+00:00)
@@ -109,6 +109,7 @@ PASS_VARIANTS = [
 
 # LWJGL versions we def. don't want!
 BAD_VARIANTS = [
+    "472ee33f7a1294822aa2d617cd6ccdfd92f949a0",  # 3.4.1 (2026-04-07 11:52:43+00:00) vulkan, has significant performance regressions
     "1fd0e4d1f0f7c97e8765a69d38225e1f27ee14ef",  # 3.4.1 (2026-02-17 12:42:24+00:00) before vulkan
     "6f32ef730d05562ede7db0b845b72ea16dd239d5",  # 3.3.3 (2024-05-29 12:04:43+00:00) missing os rule for freetype natives-macos-patch
     "8a9b08f11271eb4de3b50e5d069949500b2c7bc1",  # 3.3.3 (2024-04-03 11:49:39+00:00) seems to have a broken libfreetype for macOS x86_64


### PR DESCRIPTION
~~no clue what this variant is, the game works fine on the official build~~ someone on Discord mentioned that it fixes significant performance regressions on Java 25. architectures that aren't supported by Mojang will keep using the official build

Closes PrismLauncher/PrismLauncher#5588