### PR TITLE
fix(updateForge): add workaround for new Forge timestamps

### DIFF
--- a/meta/model/mojang.py
+++ b/meta/model/mojang.py
@@ -24,6 +24,7 @@ DEFAULT_JAVA_NAME = (
 )
 COMPATIBLE_JAVA_MAPPINGS = {16: [17]}
 SUPPORTED_FEATURES = ["is_quick_play_multiplayer", "is_quick_play_singleplayer"]
+BROKEN_TZ_SUFFIX = "+0:00"
 
 """
 Mojang index files look like this:
@@ -261,6 +262,12 @@ class MojangVersion(MetaBase):
     @validator("compliance_level")
     def validate_compliance_level(cls, v):
         assert v <= SUPPORTED_COMPLIANCE_LEVEL
+        return v
+
+    @validator("release_time", "time", pre=True)
+    def validate_datetime(cls, v: str):
+        if v.endswith(BROKEN_TZ_SUFFIX):
+            return v.replace(BROKEN_TZ_SUFFIX, "+00:00")
         return v
 
     id: str  # TODO: optional?

--- a/meta/run/update_forge.py
+++ b/meta/run/update_forge.py
@@ -191,8 +191,12 @@ def process_forge_version(version, jar_path):
                 with jar.open("version.json") as profile_zip_entry:
                     version_data = profile_zip_entry.read()
 
-                    # Process: does it parse?
-                    MojangVersion.parse_raw(version_data)
+                    try:
+                        # Process: does it parse?
+                        MojangVersion.parse_raw(version_data)
+                    except Exception as e:
+                        e.add_note(f"version_data: {version_data}")
+                        raise e
 
                     with open(version_file_path, "wb") as versionJsonFile:
                         versionJsonFile.write(version_data)


### PR DESCRIPTION
It's dirty, but so is the whole codebase :/
