### PR TITLE
Add Babric mod loader support

### DIFF
--- a/meta/common/babric.py
+++ b/meta/common/babric.py
@@ -1,0 +1,13 @@
+from os.path import join
+
+GLASS_MAVEN = "https://maven.glass-launcher.net/babric/"
+BABRIC_META = "https://meta.babric.glass-launcher.net/"
+
+BASE_DIR = "babric"
+META_DIR = join(BASE_DIR, "meta-v2")
+JARS_DIR = join(BASE_DIR, "jars")
+
+LOADER_COMPONENT = "babric"
+INTERMEDIARY_COMPONENT = "net.fabricmc.intermediary"
+
+DATETIME_FORMAT_HTTP = "%a, %d %b %Y %H:%M:%S %Z"

--- a/meta/run/generate_babric.py
+++ b/meta/run/generate_babric.py
@@ -1,0 +1,130 @@
+import json
+import os
+from datetime import datetime
+
+from meta.common import (
+    ensure_component_dir,
+    launcher_path,
+    upstream_path,
+    transform_maven_key,
+)
+from meta.common.babric import (
+    GLASS_MAVEN,
+    JARS_DIR,
+    META_DIR,
+    LOADER_COMPONENT,
+    INTERMEDIARY_COMPONENT,
+)
+from meta.model import MetaVersion, Dependency, Library, MetaPackage, GradleSpecifier
+from meta.model.fabric import FabricJarInfo
+
+LAUNCHER_DIR = launcher_path()
+UPSTREAM_DIR = upstream_path()
+
+ensure_component_dir(LOADER_COMPONENT)
+
+
+def load_jar_info(artifact_key) -> FabricJarInfo:
+    return FabricJarInfo.parse_file(
+        os.path.join(UPSTREAM_DIR, JARS_DIR, f"{artifact_key}.json")
+    )
+
+
+def process_intermediary_version(entry, release_time: datetime) -> MetaVersion:
+    v = MetaVersion(
+        name="Intermediary Mappings",
+        uid=INTERMEDIARY_COMPONENT,
+        version=entry["version"],
+    )
+    v.release_time = release_time
+    v.requires = [Dependency(uid="net.minecraft", equals=entry["version"])]
+    v.order = 11
+    v.type = "release"
+    v.volatile = True
+    v.libraries = [
+        Library(
+            name=GradleSpecifier.from_string(entry["maven"]),
+            url=GLASS_MAVEN,
+        )
+    ]
+    return v
+
+
+def process_babric_version(mc_version: str, release_time: datetime) -> MetaVersion:
+    v = MetaVersion(
+        name="Babric",
+        uid=LOADER_COMPONENT,
+        version=mc_version,
+    )
+    v.release_time = release_time
+    v.requires = [Dependency(uid="net.minecraft", equals=mc_version)]
+    v.order = 10
+    v.type = "release"
+    v.additional_jvm_args = ["-DFabricMcEmu=net.minecraft.client.main.Main"]
+    v.libraries = [
+        Library(
+            name=GradleSpecifier.from_string("babric:log4j-config:1.0.0"),
+            url=GLASS_MAVEN,
+        )
+    ]
+    return v
+
+
+def ensure_intermediary_package():
+    """Create a minimal package.json for net.fabricmc.intermediary if fabric hasn't done so yet."""
+    package_path = os.path.join(LAUNCHER_DIR, INTERMEDIARY_COMPONENT, "package.json")
+    if not os.path.exists(package_path):
+        ensure_component_dir(INTERMEDIARY_COMPONENT)
+        package = MetaPackage(uid=INTERMEDIARY_COMPONENT, name="Intermediary Mappings")
+        package.recommended = []
+        package.description = (
+            "Intermediary mappings allow using Fabric Loader with mods for Minecraft "
+            "in a more compatible manner."
+        )
+        package.project_url = "https://fabricmc.net"
+        package.authors = ["Fabric Developers"]
+        package.write(package_path)
+
+
+def main():
+    recommended_babric_versions = []
+
+    with open(
+        os.path.join(UPSTREAM_DIR, META_DIR, "intermediary.json"), "r", encoding="utf-8"
+    ) as f:
+        intermediary_index = json.load(f)
+
+    ensure_intermediary_package()
+
+    for entry in intermediary_index:
+        mc_version = entry["version"]
+        print(f"Processing Babric for Minecraft {mc_version}")
+
+        jar_info = load_jar_info(transform_maven_key(entry["maven"]))
+        release_time = jar_info.release_time
+
+        intermediary = process_intermediary_version(entry, release_time)
+        intermediary.write(
+            os.path.join(LAUNCHER_DIR, INTERMEDIARY_COMPONENT, f"{mc_version}.json")
+        )
+
+        babric = process_babric_version(mc_version, release_time)
+        babric.write(
+            os.path.join(LAUNCHER_DIR, LOADER_COMPONENT, f"{mc_version}.json")
+        )
+
+        if entry.get("stable", True):
+            recommended_babric_versions.append(mc_version)
+
+    package = MetaPackage(uid=LOADER_COMPONENT, name="Babric")
+    package.recommended = recommended_babric_versions
+    package.description = (
+        "Babric is a Fabric-based mod loader for Minecraft Beta 1.7.3."
+    )
+    package.project_url = "https://github.com/babric"
+    package.authors = ["Babric Contributors"]
+    package.write(os.path.join(LAUNCHER_DIR, LOADER_COMPONENT, "package.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/meta/run/update_babric.py
+++ b/meta/run/update_babric.py
@@ -1,0 +1,105 @@
+import json
+import os
+import zipfile
+from datetime import datetime
+
+import requests
+
+from meta.common import (
+    upstream_path,
+    ensure_upstream_dir,
+    transform_maven_key,
+    default_session,
+)
+from meta.common.babric import (
+    GLASS_MAVEN,
+    BABRIC_META,
+    JARS_DIR,
+    META_DIR,
+    DATETIME_FORMAT_HTTP,
+)
+from meta.model.fabric import FabricJarInfo
+
+UPSTREAM_DIR = upstream_path()
+
+ensure_upstream_dir(JARS_DIR)
+ensure_upstream_dir(META_DIR)
+
+sess = default_session()
+
+
+def get_maven_url(maven_key, server, ext):
+    parts = maven_key.split(":", 3)
+    maven_ver_url = (
+        server + parts[0].replace(".", "/") + "/" + parts[1] + "/" + parts[2] + "/"
+    )
+    maven_url = maven_ver_url + parts[1] + "-" + parts[2] + ext
+    return maven_url
+
+
+def get_json_file(path, url):
+    with open(path, "w", encoding="utf-8") as f:
+        r = sess.get(url)
+        r.raise_for_status()
+        version_json = r.json()
+        json.dump(version_json, f, sort_keys=True, indent=4)
+        return version_json
+
+
+def head_file(url):
+    r = sess.head(url)
+    r.raise_for_status()
+    return r.headers
+
+
+def get_binary_file(path, url):
+    r = sess.get(url)
+    r.raise_for_status()
+    with open(path, "wb") as f:
+        for chunk in r.iter_content(chunk_size=128):
+            f.write(chunk)
+
+
+def compute_jar_file(path, url):
+    try:
+        headers = head_file(url)
+        tstamp = datetime.strptime(headers["Last-Modified"], DATETIME_FORMAT_HTTP)
+    except (requests.HTTPError, KeyError):
+        print(f"Falling back to downloading jar for {url}")
+        jar_path = path + ".jar"
+        get_binary_file(jar_path, url)
+        tstamp = datetime.fromtimestamp(0)
+        with zipfile.ZipFile(jar_path) as jar:
+            allinfo = jar.infolist()
+            for info in allinfo:
+                tstamp_new = datetime(*info.date_time)
+                if tstamp_new > tstamp:
+                    tstamp = tstamp_new
+
+    data = FabricJarInfo(release_time=tstamp)
+    data.write(path + ".json")
+
+
+def main():
+    for component in ["intermediary", "loader"]:
+        get_json_file(
+            os.path.join(UPSTREAM_DIR, META_DIR, f"{component}.json"),
+            f"{BABRIC_META}v2/versions/{component}",
+        )
+
+    with open(
+        os.path.join(UPSTREAM_DIR, META_DIR, "intermediary.json"), "r", encoding="utf-8"
+    ) as f:
+        intermediary_index = json.load(f)
+
+    for entry in intermediary_index:
+        print(f"Processing intermediary {entry['version']}")
+        jar_url = get_maven_url(entry["maven"], GLASS_MAVEN, ".jar")
+        compute_jar_file(
+            os.path.join(UPSTREAM_DIR, JARS_DIR, transform_maven_key(entry["maven"])),
+            jar_url,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ documentation = "https://github.com/PrismLauncher/meta"
 keywords = ["metadata", "prism", "launcher"]
 
 [tool.poetry.scripts]
+generateBabric = "meta.run.generate_babric:main"
 generateFabric = "meta.run.generate_fabric:main"
 generateForge = "meta.run.generate_forge:main"
 generateLiteloader = "meta.run.generate_liteloader:main"
@@ -17,6 +18,7 @@ generateMojang = "meta.run.generate_mojang:main"
 generateNeoForge = "meta.run.generate_neoforge:main"
 generateQuilt = "meta.run.generate_quilt:main"
 generateJava = "meta.run.generate_java:main"
+updateBabric = "meta.run.update_babric:main"
 updateFabric = "meta.run.update_fabric:main"
 updateForge = "meta.run.update_forge:main"
 updateLiteloader = "meta.run.update_liteloader:main"

--- a/update.sh
+++ b/update.sh
@@ -39,6 +39,7 @@ python -m meta.run.update_mojang || fail_in
 python -m meta.run.update_forge || fail_in
 python -m meta.run.update_neoforge || fail_in
 python -m meta.run.update_fabric || fail_in
+python -m meta.run.update_babric || fail_in
 python -m meta.run.update_quilt || fail_in
 python -m meta.run.update_liteloader || fail_in
 python -m meta.run.update_java || fail_in
@@ -48,6 +49,7 @@ if [ "${DEPLOY_TO_GIT}" = true ]; then
     upstream_git add forge/*.json forge/version_manifests/*.json forge/installer_manifests/*.json forge/files_manifests/*.json forge/installer_info/*.json forge/jars/*.sha1 || fail_in
     upstream_git add neoforge/*.json neoforge/version_manifests/*.json neoforge/installer_manifests/*.json neoforge/files_manifests/*.json neoforge/installer_info/*.json neoforge/jars/*.sha1 || fail_in
     upstream_git add fabric/loader-installer-json/*.json fabric/meta-v2/*.json fabric/jars/*.json || fail_in
+    upstream_git add babric/meta-v2/*.json babric/jars/*.json || fail_in
     upstream_git add quilt/loader-installer-json/*.json quilt/meta-v3/*.json quilt/jars/*.json || fail_in
     upstream_git add liteloader/*.json || fail_in
     upstream_git add java_runtime/adoptium/available_releases.json java_runtime/adoptium/versions/*.json java_runtime/azul/packages.json java_runtime/azul/versions/*.json java_runtime/ibm/available_releases.json java_runtime/ibm/versions/*.json || fail_in
@@ -64,6 +66,7 @@ python -m meta.run.generate_mojang || fail_out
 python -m meta.run.generate_forge || fail_out
 python -m meta.run.generate_neoforge || fail_out
 python -m meta.run.generate_fabric || fail_out
+python -m meta.run.generate_babric || fail_out
 python -m meta.run.generate_quilt || fail_out
 python -m meta.run.generate_liteloader || fail_out
 python -m meta.run.generate_java || fail_out
@@ -74,6 +77,7 @@ if [ "${DEPLOY_TO_GIT}" = true ]; then
     launcher_git add net.minecraftforge/* || fail_out
     launcher_git add net.neoforged/* || fail_out
     launcher_git add net.fabricmc.fabric-loader/* net.fabricmc.intermediary/* || fail_out
+    launcher_git add babric/* || fail_out
     launcher_git add org.quiltmc.quilt-loader/* || fail_out # TODO: add Quilt hashed, once it is actually used
     launcher_git add com.mumfrey.liteloader/* || fail_out
     launcher_git add net.minecraft.java/* net.adoptium.java/* com.azul.java/* com.ibm.java/* || fail_out


### PR DESCRIPTION
Co-Authored-By: Claude:claude-4.6-sonnet

Adds support for [Babric](https://github.com/babric) - a Fabric-based mod loader for Minecraft Beta 1.7.3. After merging, Prism Launcher will be able to install and launch Babric the same way it handles Fabric or Quilt. I've made a [pull request](https://github.com/PrismLauncher/PrismLauncher/pull/5730) for the main repository, but I was advised to add Babric to the meta server first

## Changes

- `meta/common/babric.py` - Glass Maven and Babric Meta API constants
- `meta/run/update_babric.py` - fetches version lists and metadata from `meta.babric.glass-launcher.net`
- `meta/run/generate_babric.py` - generates two launcher components per Minecraft version:
  - `babric/{version}.json` - the loader itself (config library + JVM argument)
  - `net.fabricmc.intermediary/{version}.json` - mappings (reuses the Fabric intermediary component)
- `update.sh` - added Babric update/generate steps to the pipeline
- `pyproject.toml` - added `updateBabric` and `generateBabric` entry points

## Test

Ran all the chcks manually, and they're passed.

`update_babric` fetched data from the Babric Meta API:
- `upstream/babric/meta-v2/intermediary.json`
- `upstream/babric/meta-v2/loader.json`
- `upstream/babric/jars/babric.intermediary-upstream.b1.7.3.json`

`generate_babric` produced all launcher files:
- `launcher/babric/b1.7.3.json` - contains `babric:log4j-config:1.0.0` library and `-DFabricMcEmu` JVM argument
- `launcher/net.fabricmc.intermediary/b1.7.3.json` - marked `volatile`, references the correct maven artifact
- `launcher/babric/package.json` - `recommended: ["b1.7.3"]`