### PR TITLE
chore: allow lwjgl-spng natives for macos-arm64 and windows-arm64

### DIFF
--- a/meta/common/mojang-library-patches.json
+++ b/meta/common/mojang-library-patches.json
@@ -60,7 +60,8 @@
       "org.lwjgl:lwjgl-shaderc-natives-macos-arm64:3.4.3",
       "org.lwjgl:lwjgl-spvc-natives-macos-arm64:3.4.3",
       "org.lwjgl:lwjgl-vma-natives-macos-arm64:3.4.3",
-      "org.lwjgl:lwjgl-sdl-natives-macos-arm64:3.4.3"
+      "org.lwjgl:lwjgl-sdl-natives-macos-arm64:3.4.3",
+      "org.lwjgl:lwjgl-spng-natives-macos-arm64:3.4.3"
     ],
     "override": {
       "rules": [
@@ -131,7 +132,8 @@
       "org.lwjgl:lwjgl-shaderc-natives-windows-arm64:3.4.3",
       "org.lwjgl:lwjgl-spvc-natives-windows-arm64:3.4.3",
       "org.lwjgl:lwjgl-vma-natives-windows-arm64:3.4.3",
-      "org.lwjgl:lwjgl-sdl-natives-windows-arm64:3.4.3"
+      "org.lwjgl:lwjgl-sdl-natives-windows-arm64:3.4.3",
+      "org.lwjgl:lwjgl-spng-natives-windows-arm64:3.4.3"
     ],
     "override": {
       "rules": [


### PR DESCRIPTION
isnt life amazing